### PR TITLE
perf: use xmltodict to reduce size of image/dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ ENV APP_HOME /app
 WORKDIR ${APP_HOME}
 ADD requirements.txt .
 RUN pip install -r requirements.txt
-RUN git clone https://github.com/tensorflow/models.git tensorflow_models
-ENV PYTHONPATH=${APP_HOME}:${APP_HOME}/tensorflow_models/research:${APP_HOME}/tensorflow_models/research/slim:${APP_HOME}/tensorflow_models/research/object_detection
+ENV PYTHONPATH=${APP_HOME}
 ADD src/main .
 
 WORKDIR /app

--- a/environment.yml
+++ b/environment.yml
@@ -6,9 +6,6 @@ channels:
 dependencies:
   - python>=3.8
   - jupyter
-  - ipykernel
-  - sagemaker
-  - tensorflow
   - pip
   - pip:
     - -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python-headless==4.5.2.54
+opencv-python-headless==4.5.5.64
 numpy
 xmltodict
 pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 opencv-python-headless==4.5.2.54
 scipy
 numpy
-lxml
+xmltodict
 pillow
 nose
-tensorflow
-tensorflow-io

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 opencv-python-headless==4.5.2.54
-scipy
 numpy
 xmltodict
 pillow


### PR DESCRIPTION
Hi @danellecline I went ahead and did this adjustment to reduce the size of the resulting image  (via removing heavy dependencies). Comparing:

```
REPOSITORY                TAG                                IMAGE ID       CREATED         SIZE
mbari/voc-imagecropper    latest                             3640c2120ba1   9 minutes ago   648MB
mbari/voc-imagecropper    <none>                             ba5e8cb1001a   2 hours ago     3.61GB
```

Good testing with your example, via direct python call and also via docker image:

```
python3 src/main/run.py -d data/annotations --image_dir data/imgs -o data/out
```

```
docker build -t mbari/voc-imagecropper .
```

```
docker run -it \
--rm -u $(id -u):$(id -g) \
-v $PWD/data:/data mbari/voc-imagecropper \
-d /data/annotations \
--image_dir /data/imgs \
-o /data/out
```

Of course please review and feel free to merge or not. (Probably there are other things that you have in mind down the road for this code, where tensorflow may be still be needed after all).